### PR TITLE
 flake: add bpir3_cross package 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,17 @@
           self.nixosModules.boards.bananapi.bpir3
         ];
       };
+
+      bananapi-bpir3_cross = bootstrapSystem {
+        modules = [
+          self.nixosModules.boards.bananapi.bpir3
+          {
+            nixpkgs.buildPlatform.system = "x86_64-linux";
+            nixpkgs.hostPlatform.system = "aarch64-linux";
+          }
+        ];
+      };
+
       pine64-rock64v2 = bootstrapSystem {
         modules = [
           self.nixosModules.boards.pine64.rock64v2


### PR DESCRIPTION
i've been running this kernel configuration since sunday in the absent of any unprecedented issues.

my x86_64-linux machine is more powerful than any of my aarch64-linux machines, hence i prefer cross compiling.

the change i'm least confident about is the kernel configuration.
i'm also puzzled why the btrfs-subvol filesystem structure isn't working for me, OTOH it's also not a priority for me.

happy to receive any and all feedback on this :blush: 