### PR TITLE
BPiR4: Build without autoModules

### DIFF
--- a/pkgs/bananaPiR4/default.nix
+++ b/pkgs/bananaPiR4/default.nix
@@ -9,6 +9,7 @@
   ubootTools,
   linuxKernel,
   linux_6_10,
+  lib,
   ...
 }: rec {
   ubootBananaPiR4 =
@@ -68,6 +69,19 @@
 
 
   linuxPackages_frankw_6_10_bananaPiR4 = linuxKernel.packagesFor (linux_6_10.override {
+    autoModules = false;
+
+    structuredExtraConfig = with lib.kernel; {
+      BTRFS_FS = module;
+      BTRFS_FS_POSIX_ACL = yes;
+
+      # Disable extremely unlikely features to reduce build storage requirements and time.
+      FB = lib.mkForce no;
+      DRM = lib.mkForce no;
+      SOUND = no;
+      INFINIBAND = lib.mkForce no;
+    };
+
     argsOverride = {
       src = fetchFromGitHub {
         owner = "frank-w";


### PR DESCRIPTION
autoModules answers every kernel config option with "M" if module is an option.  This makes the kernel extremely large and the compile times outlandish as everything from AMDGPU to ZISOFS is built.

As the kernel currently in use has a defconfig tailored to the BPiR4 we need to do very little to produce a functional system.  Common config is left to turn on as much as it can find, minus a few exclusions, and we add BTRFS support.