### PR TITLE
bpir4: update RTC info

### DIFF
--- a/modules/boards/bananapi/bpir4/info.md
+++ b/modules/boards/bananapi/bpir4/info.md
@@ -22,11 +22,6 @@ Kernel param `clk_ignore_unused=1` is set as if linux shuts down unknown clocks 
 PCIe root does not appear, meaning PCIe is not functional at this time.
 
 
-### RTC
-
-Missing kernel driver.
-
-
 ### Module loads at boot
 
 As referenced in the pull that added support:


### PR DESCRIPTION
After buying an RTC battery the RTC is functional for me: `rtc-pcf8563 2-0051: registered as rtc0`