### PR TITLE
WIP: btrfs-subvol support impermanence on provision

### DIFF
--- a/modules/sbc/bootstrap/default.nix
+++ b/modules/sbc/bootstrap/default.nix
@@ -77,66 +77,46 @@ in {
           '';
         };
 
-        rootfsBtrfsImage = pkgs.callPackage (pkgs.path + "/nixos/lib/make-btrfs-fs.nix") {
+        rootfsBtrfsImage = pkgs.callPackage ./make-btrfs-fs.nix {
           storePaths = config.system.build.toplevel;
           compressImage = false;
           volumeLabel = "root";
           uuid = "18db6211-ac36-42c1-a22f-5e15e1486e0d";
-          populateImageCommands = let
-            ramify = ''
-              touch ./files/NIXOS_RAMIFY
-            '';
-          in
-            ''
-              mkdir ./files/boot
-              ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./files/boot
-            ''
-            + (
-              if cfg.rootFilesystem == "btrfs-subvol"
-              then ramify
-              else ""
-            );
+          btrfs-progs = pkgs.btrfs-progs.overrideAttrs (oldAttrs: {
+            src = pkgs.fetchFromGitHub {
+              owner = "kdave";
+              repo = "btrfs-progs";
+              # devel 2024.09.10; Remove v6.11 release.
+              rev = "c75b2f2c77c9fdace08a57fe4515b45a4616fa21";
+              hash = "sha256-PgispmDnulTDeNnuEDdFO8FGWlGx/e4cP8MQMd9opFw=";
+            };
+
+            postPatch = "";
+
+            nativeBuildInputs =
+              oldAttrs.nativeBuildInputs
+              ++ [
+                pkgs.autoconf
+                pkgs.automake
+              ];
+            preConfigure = "./autogen.sh";
+
+            version = "6.11.0.pre";
+          });
+          populateImageCommands = ''
+            mkdir ./files/boot
+            ${config.boot.loader.generic-extlinux-compatible.populateCmd} -c ${config.system.build.toplevel} -d ./files/boot
+          '';
+          subvolMap = {
+            "/" = "@";
+            "/nix" = "@nix";
+            "/boot" = "@boot";
+          };
         };
       in
         if (builtins.elem cfg.rootFilesystem ["btrfs" "btrfs-subvol"])
         then rootfsBtrfsImage
         else rootfsExt4Image;
-
-      # postResumeCommands is right before mount happens, and after a bunch of helper functions are defined.
-      boot.initrd.postResumeCommands = let
-        # Root device should become /nix so users can go directly to impermanence.
-        # But that's not supported yet with the whole /nix-path-registration thing
-        rootDevice = (builtins.head (builtins.filter (fs: fs.mountPoint == "/") config.system.build.fileSystems)).device;
-      in
-        # FIXME: Support impermanence on first-boot
-        lib.mkIf (cfg.rootFilesystem == "btrfs-subvol" && rootDevice != "none") ''
-          mkdir -p $targetRoot
-          ramifyDevice=${rootDevice}
-          waitDevice "$ramifyDevice"
-          mount -t btrfs -o compress=zstd $ramifyDevice $targetRoot
-          if [ -f $targetRoot/NIXOS_RAMIFY -a ! -d $targetRoot/@ ]; then
-            ${pkgs.btrfs-progs}/bin/btrfs subvolume snapshot $targetRoot $targetRoot/@nix
-            ${pkgs.btrfs-progs}/bin/btrfs subvolume create $targetRoot/@boot
-            ${pkgs.btrfs-progs}/bin/btrfs subvolume create $targetRoot/@
-
-            # Remove /nix from top-level subvolume before anything else as /nix
-            # holds a lot of metadata in btrfs, especially if nixpkgs is included.
-            rm -rf $targetRoot/nix
-
-            find $targetRoot/@nix -mindepth 1 -maxdepth 1 -not -path "$targetRoot/@nix/nix" -exec rm -rf {} \;
-            mv $targetRoot/@nix/nix/* $targetRoot/@nix/
-            rmdir $targetRoot/@nix/nix
-
-            cp -a --reflink $targetRoot/boot/* $targetRoot/@boot/
-            rm -rf $targetRoot/boot
-
-            find $targetRoot -mindepth 1 -maxdepth 1 -not -path "$targetRoot/@*" -exec cp -a --reflink {} $targetRoot/@ \;
-            find $targetRoot -mindepth 1 -maxdepth 1 -not -path "$targetRoot/@*" -exec rm -rf {} \;
-
-            rm $targetRoot/@/NIXOS_RAMIFY
-          fi
-          umount $targetRoot
-        '';
 
       boot.postBootCommands = let
         btrfsResizeCommands = ''

--- a/modules/sbc/bootstrap/make-btrfs-fs.nix
+++ b/modules/sbc/bootstrap/make-btrfs-fs.nix
@@ -16,7 +16,7 @@
 , uuid ? "44444444-4444-4444-8888-888888888888"
 , btrfs-progs
 , libfaketime
-, fakeroot
+, util-linux
 , subvolMap ? {}
 }:
 
@@ -26,7 +26,7 @@ in
 pkgs.stdenv.mkDerivation {
   name = "btrfs-fs.img${lib.optionalString compressImage ".zst"}";
 
-  nativeBuildInputs = [ btrfs-progs libfaketime fakeroot ] ++ lib.optional compressImage zstd;
+  nativeBuildInputs = [ btrfs-progs libfaketime util-linux ] ++ lib.optional compressImage zstd;
 
   buildCommand =
     let
@@ -73,7 +73,7 @@ pkgs.stdenv.mkDerivation {
       ${subvolMovePaths}
 
       touch $img
-      faketime -f "1970-01-01 00:00:01" fakeroot mkfs.btrfs -L ${volumeLabel} -U ${uuid} ${subvolMkfsArgs} -r ./rootImage --shrink $img
+      faketime -f "1970-01-01 00:00:01" unshare -U -r mkfs.btrfs -L ${volumeLabel} -U ${uuid} ${subvolMkfsArgs} -r ./rootImage --shrink $img
 
       if ! btrfs check $img; then
         echo "--- 'btrfs check' failed for BTRFS image ---"

--- a/modules/sbc/bootstrap/make-btrfs-fs.nix
+++ b/modules/sbc/bootstrap/make-btrfs-fs.nix
@@ -67,7 +67,7 @@ pkgs.stdenv.mkDerivation {
         done
       )
 
-      cp ${sdClosureInfo}/registration ./rootImage/nix-path-registration
+      cp ${sdClosureInfo}/registration ./rootImage/nix/nix-path-registration
 
       ${rootSubvolCmd}
       ${subvolMovePaths}

--- a/modules/sbc/bootstrap/make-btrfs-fs.nix
+++ b/modules/sbc/bootstrap/make-btrfs-fs.nix
@@ -43,7 +43,7 @@ pkgs.stdenv.mkDerivation {
       '';
 
       filteredSubvolMap = builtins.removeAttrs subvolMap ["/"];
-      subvolMovePaths = builtins.concatStringsSep "\n" (builtins.attrValues (builtins.mapAttrs (origPath: subvolPath: "mv ${rootImagePath}/${origPath} ./rootImage/${subvolPath}") filteredSubvolMap));
+      subvolMovePaths = builtins.concatStringsSep "\n" (builtins.attrValues (builtins.mapAttrs (origPath: subvolPath: "[ -d ${rootImagePath}/${origPath} ] && mv ${rootImagePath}/${origPath} ./rootImage/${subvolPath} || mkdir ./rootImage/${subvolPath}") filteredSubvolMap));
       subvolMkfsArgs = builtins.concatStringsSep " " (builtins.attrValues (builtins.mapAttrs (_: subvolPath: "--subvol \"${subvolPath}\"") subvolMap));
     in
     ''

--- a/modules/sbc/bootstrap/make-btrfs-fs.nix
+++ b/modules/sbc/bootstrap/make-btrfs-fs.nix
@@ -1,0 +1,88 @@
+# Builds an btrfs image containing a populated /nix/store with the closure
+# of store paths passed in the storePaths parameter, in addition to the
+# contents of a directory that can be populated with commands. The
+# generated image is sized to only fit its contents, with the expectation
+# that a script resizes the filesystem at boot time.
+{ pkgs
+, lib
+# List of derivations to be included
+, storePaths
+# Whether or not to compress the resulting image with zstd
+, compressImage ? false, zstd
+# Shell commands to populate the ./files directory.
+# All files in that directory are copied to the root of the FS.
+, populateImageCommands ? ""
+, volumeLabel
+, uuid ? "44444444-4444-4444-8888-888888888888"
+, btrfs-progs
+, libfaketime
+, fakeroot
+, subvolMap ? {}
+}:
+
+let
+  sdClosureInfo = pkgs.buildPackages.closureInfo { rootPaths = storePaths; };
+in
+pkgs.stdenv.mkDerivation {
+  name = "btrfs-fs.img${lib.optionalString compressImage ".zst"}";
+
+  nativeBuildInputs = [ btrfs-progs libfaketime fakeroot ] ++ lib.optional compressImage zstd;
+
+  buildCommand =
+    let
+      # XXX: Nested subvols will not work
+      rootIsSubvol = builtins.elem "/" (builtins.attrNames subvolMap);
+      rootImagePath =
+        if rootIsSubvol
+        then "./rootImage/${subvolMap."/"}"
+        else "./rootImage";
+      rootSubvolCmd = lib.optionalString rootIsSubvol ''
+        mv ./rootImage rootSubVol
+        mkdir ./rootImage
+        mv ./rootSubVol ./rootImage/${subvolMap."/"}
+      '';
+
+      filteredSubvolMap = builtins.removeAttrs subvolMap ["/"];
+      subvolMovePaths = builtins.concatStringsSep "\n" (builtins.attrValues (builtins.mapAttrs (origPath: subvolPath: "mv ${rootImagePath}/${origPath} ./rootImage/${subvolPath}") filteredSubvolMap));
+      subvolMkfsArgs = builtins.concatStringsSep " " (builtins.attrValues (builtins.mapAttrs (_: subvolPath: "--subvol \"${subvolPath}\"") subvolMap));
+    in
+    ''
+      ${if compressImage then "img=temp.img" else "img=$out"}
+
+      set -x
+      (
+          mkdir -p ./files
+          ${populateImageCommands}
+      )
+
+      mkdir -p ./rootImage/nix/store
+
+      xargs -I % cp -a --reflink=auto % -t ./rootImage/nix/store/ < ${sdClosureInfo}/store-paths
+      (
+        GLOBIGNORE=".:.."
+        shopt -u dotglob
+
+        for f in ./files/*; do
+            cp -a --reflink=auto -t ./rootImage/ "$f"
+        done
+      )
+
+      cp ${sdClosureInfo}/registration ./rootImage/nix-path-registration
+
+      ${rootSubvolCmd}
+      ${subvolMovePaths}
+
+      touch $img
+      faketime -f "1970-01-01 00:00:01" fakeroot mkfs.btrfs -L ${volumeLabel} -U ${uuid} ${subvolMkfsArgs} -r ./rootImage --shrink $img
+
+      if ! btrfs check $img; then
+        echo "--- 'btrfs check' failed for BTRFS image ---"
+        return 1
+      fi
+
+      if [ ${builtins.toString compressImage} ]; then
+        echo "Compressing image"
+        zstd -v --no-progress ./$img -o $out
+      fi
+    '';
+}

--- a/modules/sbc/filesystem.nix
+++ b/modules/sbc/filesystem.nix
@@ -27,6 +27,13 @@ in {
       );
     }
     (lib.mkIf (config.sbc.enable && cfg.useDefaultLayout == "btrfs-subvol") {
+      assertions = [
+        {
+          assertion = builtins.all (fs: (fs.device == "/dev/disk/by-uuid/18db6211-ac36-42c1-a22f-5e15e1486e0d") -> !(builtins.any (opt: lib.hasPrefix "subvolid=" opt) fs.options)) config.system.build.fileSystems;
+          message = "subvolid is not idempotent, can't reproduce, refusing to build";
+        }
+      ];
+
       fileSystems = {
         "/" = {
           device = "/dev/disk/by-uuid/18db6211-ac36-42c1-a22f-5e15e1486e0d";


### PR DESCRIPTION
Currently you have to boot the system once before you can convert it to impermanence, manually creating your persistent data subvol and then after switching to it, deleting the `@` subvol.

This is suboptimal, and it should be possible to directly provision with impermanence.

First up, the RAMIFY tooling is annoying, and now that btrfs-progs will (soon) support subvol creation during mkfs, throw that all away and use it instead, removing the risk of the metadata allocation filling up during the shuffle and throwing ENOSPC.  As the in-line override is only used during the build of the sdImage, it's contained away from everything else enough I'm happy to do this for now, I expect it'll be able to be removed in a month.

Second with impermanence, / won't be around, so we need to pick someplace that will be persistent to hold nix-path-registration.  All of /nix is probably persistent, and I don't really want to stuff it into /nix/store, so into /nix it goes.  It's a bootstrap detail, so it's created during sdImage creation and used on first-boot, we can change its location however we want without breaking live systems.

Finally, we work out the subvolMap passed to the forked *make-btrfs-fs* from config.system.build.fileSystems(?) so `/` can be a tmpfs.  It could use some more asserts for sanity checking, but is otherwise ready to go.

Last patch is not boot tested yet, as the first pass missed re-sizing, so I need to re-run that.

Ref: #18 