### PR TITLE
No Fxup for raspberryPiFirmware disk image

### DIFF
--- a/pkgs/raspberrypi/default.nix
+++ b/pkgs/raspberrypi/default.nix
@@ -50,6 +50,7 @@ in {
     name = "raspberryPiFirmware.img";
 
     nativeBuildInputs = [dosfstools mtools];
+    dontFixup = true;
 
     buildPhase = ''
       size=$((32 * 1024 * 1024))


### PR DESCRIPTION
default mkDerevation will patch and strip the resulting binary. The outputbinary in this case is a vfat disk image.

noFixup

Fixes https://github.com/nakato/nixos-sbc/issues/22

```
› nix log /nix/store/slrail663w21nd8sqqniiz0c064bbhwy-raspberryPiFirmware.img.drv
warning: The interpretation of store paths arguments ending in `.drv` recently changed. If this command is now failing try again with '/nix/store/slrail663w21nd8sqqniiz0c064bbhwy-raspberryPiFirmware.img.drv^*'
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "configurePhase" }
Running phase: configurePhase
no configure script, doing nothing
@nix { "action": "setPhase", "phase": "buildPhase" }
Running phase: buildPhase
mkfs.fat 4.2 (2021-01-31)
mkfs.fat: Warning: lowercase labels might not work properly on some systems
Copying armstub8-gic.bin
Copying bcm2711-rpi-4-b.dtb
Copying bootcode.bin
Copying config.txt
Copying fixup.dat
Copying fixup4.dat
Copying fixup4cd.dat
Copying fixup4db.dat
Copying fixup4x.dat
Copying fixup_cd.dat
Copying fixup_db.dat
Copying fixup_x.dat
Copying start.elf
Copying start4.elf
Copying start4cd.elf
Copying start4db.elf
Copying start4x.elf
Copying start_cd.elf
Copying start_db.elf
Copying start_x.elf
Copying u-boot-pi4.bin
fsck.fat 4.2 (2021-01-31)
Checking we can access the last sector of the filesystem
Boot sector contents:
System ID "mkfs.fat"
Media byte 0xf8 (hard disk)
       512 bytes per logical sector
      2048 bytes per cluster
         4 reserved sectors
First FAT starts at byte 2048 (sector 4)
         2 FATs, 16 bit entries
     32768 bytes per FAT (= 64 sectors)
Root directory starts at byte 67584 (sector 132)
       512 root directory entries
Data area starts at byte 83968 (sector 164)
     16343 data clusters (33470464 bytes)
32 sectors/track, 4 heads
         0 hidden sectors
     65536 sectors total
Checking for unused clusters.
firmware.img: 22 files, 11273/16343 clusters
@nix { "action": "setPhase", "phase": "installPhase" }
Running phase: installPhase
```