### PR TITLE
Use all cores when compressing BTRFS image

### DIFF
--- a/modules/boards/bananapi/bpir3/sd-image-mt7986.nix
+++ b/modules/boards/bananapi/bpir3/sd-image-mt7986.nix
@@ -86,7 +86,7 @@
           dd conv=notrunc if=$root_fs of=$img seek=$rootPartStart
 
           if [ ${builtins.toString compress} = 1 ]; then
-            zstd --rm -T0 -19 $img
+            zstd --rm -T$NIX_BUILD_CORES -19 $img
           fi
         '';
       }

--- a/modules/boards/bananapi/bpir4/sd-image-mt7988.nix
+++ b/modules/boards/bananapi/bpir4/sd-image-mt7988.nix
@@ -87,7 +87,7 @@
           dd conv=notrunc if=$root_fs of=$img seek=$rootPartStart
 
           if [ ${builtins.toString compress} = 1 ]; then
-            zstd --rm -T0 -19 $img
+            zstd --rm -T$NIX_BUILD_CORES -19 $img
           fi
         '';
       }

--- a/modules/boards/pine64/rock64/sd-image.nix
+++ b/modules/boards/pine64/rock64/sd-image.nix
@@ -85,7 +85,7 @@ in {
           dd conv=notrunc if=$root_fs of=$img seek=$rootPartStart
 
           if [ ${builtins.toString compress} = 1 ]; then
-            zstd --rm -T0 -19 $img
+            zstd --rm -T$NIX_BUILD_CORES -19 $img
           fi
         '';
       }

--- a/modules/boards/raspberrypi/sd-image-rpi.nix
+++ b/modules/boards/raspberrypi/sd-image-rpi.nix
@@ -70,7 +70,7 @@
           dd conv=notrunc if=$root_fs of=$img seek=$rootPartStart
 
           if [ ${builtins.toString compress} = 1 ]; then
-            zstd --rm -T0 -19 $img
+            zstd --rm -T$NIX_BUILD_CORES -19 $img
           fi
         '';
       }

--- a/modules/boards/xunlong/opi5/sd-image.nix
+++ b/modules/boards/xunlong/opi5/sd-image.nix
@@ -81,7 +81,7 @@
           dd conv=notrunc if=$root_fs of=$img seek=$rootPartStart
 
           if [ ${builtins.toString compress} = 1 ]; then
-            zstd --rm -T0 -19 $img
+            zstd --rm -T$NIX_BUILD_CORES -19 $img
           fi
         '';
       }

--- a/modules/sbc/bootstrap/make-btrfs-fs.nix
+++ b/modules/sbc/bootstrap/make-btrfs-fs.nix
@@ -82,7 +82,7 @@ pkgs.stdenv.mkDerivation {
 
       if [ ${builtins.toString compressImage} ]; then
         echo "Compressing image"
-        zstd -v --no-progress ./$img -o $out
+        zstd -T0 -v --no-progress ./$img -o $out
       fi
     '';
 }

--- a/modules/sbc/bootstrap/make-btrfs-fs.nix
+++ b/modules/sbc/bootstrap/make-btrfs-fs.nix
@@ -82,7 +82,7 @@ pkgs.stdenv.mkDerivation {
 
       if [ ${builtins.toString compressImage} ]; then
         echo "Compressing image"
-        zstd -T0 -v --no-progress ./$img -o $out
+        zstd -T$NIX_BUILD_CORES -v --no-progress ./$img -o $out
       fi
     '';
 }


### PR DESCRIPTION
Use all cores. This will make a great difference since the BTRFS image can be quite large.

Everywhere else -19 compression level is also used. But I don't feel strongly about it. Arm CPU cycles might be more expensive than Megabytes.