### PR TITLE
BPiR4: disable systemd TPM2 support

### DIFF
--- a/modules/boards/bananapi/bpir4/default.nix
+++ b/modules/boards/bananapi/bpir4/default.nix
@@ -68,6 +68,8 @@
     boot.initrd.includeDefaultModules = false;
     boot.initrd.kernelModules = ["mii"];
     boot.initrd.availableKernelModules = ["nvme"];
+    # When using systemd as stage 1, disable TPM support, as the vendor's kernel does not support tpm-tis.
+    boot.initrd.systemd.tpm2.enable = false;
 
     hardware.deviceTree.filter = "mt7988a-bananapi-bpi-r4.dtb";
     hardware.deviceTree.overlays = [


### PR DESCRIPTION
NixOS enables this option if systemd is built with TPM2 support, but the BPiR4 kernel does not support it it seems.

Related https://github.com/NixOS/nixpkgs/issues/344963
