### PR TITLE
add bpir3 patch to avoid crashing the device on missing band information

### DIFF
--- a/pkgs/bananaPiR3/780-avoid-crashing-missing-band.patch
+++ b/pkgs/bananaPiR3/780-avoid-crashing-missing-band.patch
@@ -1,0 +1,34 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Thu, 30 Nov 2023 07:32:52 +0100
+Subject: [PATCH] mac80211: avoid crashing on invalid band info
+
+Frequent crashes have been observed on MT7916 based platforms. While the
+root of these crashes are currently unknown, they happen when decoding
+rate information of connected STAs in AP mode. The rate-information is
+associated with a band which is not available on the PHY.
+
+Check for this condition in order to avoid crashing the whole system.
+This patch should be removed once the roout cause has been found and
+fixed.
+
+Link: https://github.com/freifunk-gluon/gluon/issues/2980
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+---
+
+--- a/net/mac80211/sta_info.c
++++ b/net/mac80211/sta_info.c
+@@ -2422,6 +2422,13 @@ static void sta_stats_decode_rate(struct
+
+ 		sband = local->hw.wiphy->bands[band];
+
++		if (!sband) {
++			wiphy_warn(local->hw.wiphy,
++				    "Invalid band %d\n",
++				    band);
++			break;
++		}
++
+ 		if (WARN_ON_ONCE(!sband->bitrates))
+ 			break;
+

--- a/pkgs/bananaPiR3/default.nix
+++ b/pkgs/bananaPiR3/default.nix
@@ -86,6 +86,10 @@
         name = "PCI: mediatek-gen3: handle PERST after reset";
         patch = ./linux-mtk-pcie.patch;
       }
+      {
+        name = "avoid-crashing-missing-band.patch";
+        patch = ./780-avoid-crashing-missing-band.patch;
+      }
     ];
 
     structuredExtraConfig = with lib.kernel; {


### PR DESCRIPTION
My bpir3 was crashing almost daily with logs like:
```
Internal error: Oops: 0000000096000006 [#1] SMP
```
I found these forum threads which described behavior very similar to the one displayed by my device:
- https://forum.banana-pi.org/t/bpi-r3-crash-in-sta-set-sinfo-0xa18/15290
- https://github.com/openwrt/openwrt/issues/13198

After applying the patch mentioned in https://forum.banana-pi.org/t/bpi-r3-crash-in-sta-set-sinfo-0xa18/15290/10, I've been running the device for 3 weeks without issue. 
This patch does not solve the underlying issue but it avoids crashing the device.