### PR TITLE
Update arm-trusted-firmware for BananaPi

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740126099,
-        "narHash": "sha256-ozoOtE2hGsqh4XkTJFsrTkNxkRgShxpQxDynaPZUGxk=",
+        "lastModified": 1742422364,
+        "narHash": "sha256-mNqIplmEohk5jRkqYqG19GA8MbQ/D4gQSK0Mu4LvfRQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "32fb99ba93fea2798be0e997ea331dd78167f814",
+        "rev": "a84ebe20c6bc2ecbcfb000a50776219f48d134cc",
         "type": "github"
       },
       "original": {

--- a/pkgs/bananaPiR3/default.nix
+++ b/pkgs/bananaPiR3/default.nix
@@ -10,6 +10,8 @@
   ncurses,
   pkg-config,
   ubootTools,
+  which,
+  python3,
   ...
 }: rec {
   ubootBananaPiR3 = buildSBCUBoot {
@@ -60,12 +62,12 @@
       src = fetchFromGitHub {
         owner = "mtk-openwrt";
         repo = "arm-trusted-firmware";
-        # mtksoc HEAD 2023-03-10
-        rev = "7539348480af57c6d0db95aba6381f3ee7483779";
-        hash = "sha256-OjM+metlaEzV7mXA8QHYEQd94p8zK34dLTqbyWQh1bQ=";
+        # mtksoc HEAD 2025-03-12
+        rev = "e090770684e775711a624e68e0b28112227a4c38";
+        hash = "sha256-VI5OB2nWdXUjkSuUXl/0yQN+/aJp9Jkt+hy7DlL+PMg=";
       };
-      version = "2.7.0-mtk";
-      nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [dtc ubootTools];
+      version = "2.12.0-mtk";
+      nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [dtc ubootTools which python3];
     });
 
   linuxPackages_6_11_bananaPiR3 = linuxKernel.packagesFor (linux_6_11.override {

--- a/pkgs/bananaPiR4/default.nix
+++ b/pkgs/bananaPiR4/default.nix
@@ -10,6 +10,8 @@
   linuxKernel,
   linux_6_12,
   lib,
+  which,
+  python3,
   ...
 }: rec {
   ubootBananaPiR4 =
@@ -59,12 +61,12 @@
       src = fetchFromGitHub {
         owner = "mtk-openwrt";
         repo = "arm-trusted-firmware";
-        # mtksoc HEAD 2024-08-02
-        rev = "bacca82a8cac369470df052a9d801a0ceb9b74ca";
-        hash = "sha256-n5D3styntdoKpVH+vpAfDkCciRJjCZf9ivrI9eEdyqw=";
+        # mtksoc HEAD 2025-03-12
+        rev = "e090770684e775711a624e68e0b28112227a4c38";
+        hash = "sha256-VI5OB2nWdXUjkSuUXl/0yQN+/aJp9Jkt+hy7DlL+PMg=";
       };
-      version = "2.10.0-mtk";
-      nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [dtc ubootTools];
+      version = "2.12.0-mtk";
+      nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [dtc ubootTools which python3];
     });
 
 


### PR DESCRIPTION
Fixes a compilation error in the current nixpkgs-unstable. The compilation changes are related to the new version of arm-trusted-firmware.

I tested the sdImage compilation on BananaPi R3/R4. The image started correctly on my BananaPi R3.