### PR TITLE
bpi-r4: linux: 6.12 -> 6.17

### DIFF
--- a/pkgs/bananaPiR4/default.nix
+++ b/pkgs/bananaPiR4/default.nix
@@ -8,10 +8,11 @@
   pkg-config,
   ubootTools,
   linuxKernel,
-  linux_6_12,
+  linux_6_17,
   lib,
   which,
   python3,
+  fetchpatch2,
   ...
 }: rec {
   ubootBananaPiR4 =
@@ -70,7 +71,7 @@
     });
 
 
-  linuxPackages_frankw_6_12_bananaPiR4 = linuxKernel.packagesFor (linux_6_12.override {
+  linuxPackages_frankw_6_17_bananaPiR4 = linuxKernel.packagesFor (linux_6_17.override {
     autoModules = false;
 
     ignoreConfigErrors = true;
@@ -247,16 +248,14 @@
       NFT_XFRM = module;
     };
 
+    kernelPatches = import ./kernel_patches.nix {
+      inherit fetchpatch2;
+    };
+
     argsOverride = {
-      src = fetchFromGitHub {
-        owner = "frank-w";
-        repo = "BPI-Router-Linux";
-        # 6.12-main HEAD 2025-04-11
-        rev = "d814d01a79010a26c1bdf5bee4827779e3c5a148";
-        hash = "sha256-KHMXDQ3AohOFbKNMRhPhracT9Hxm2lVi8QyNaiDnrlE=";
-      };
-      version = "6.12.23-bpi-r4";
-      modDirVersion = "6.12.23-bpi-r4";
+      version = "${linux_6_17.version}-bpi-r4";
+      modDirVersion = "${linux_6_17.version}-bpi-r4";
+      ignoreConfigErrors = true;
     };
 
     defconfig = "mt7988a_bpi-r4_defconfig";
@@ -264,5 +263,5 @@
     extraMeta.vendorKernel = true;
   });
 
-  linuxPackages_frankw_latest_bananaPiR4 = linuxPackages_frankw_6_12_bananaPiR4;
+  linuxPackages_frankw_latest_bananaPiR4 = linuxPackages_frankw_6_17_bananaPiR4;
 }

--- a/pkgs/bananaPiR4/kernel_patches.nix
+++ b/pkgs/bananaPiR4/kernel_patches.nix
@@ -1,0 +1,58 @@
+{fetchpatch2}: [
+  {
+    name = "build.sh: add build script,config,defconfig and fit source";
+    patch = fetchpatch2 {
+      url = "https://github.com/frank-w/BPI-Router-Linux/commit/0890d2e6cc32d7fa7494a92970e370d21b9e8d31.patch?full_index=1";
+      hash = "sha256-H23zjURqfV7/goKzbGXmz/1A6Jd5+UXyvwTRCb67AJY=";
+    };
+  }
+  {
+    name = "defconfig: r4: add sram driver";
+    patch = fetchpatch2 {
+      url = "https://github.com/frank-w/BPI-Router-Linux/commit/34c94818ab43ebc59773f5035804f665b1519ee4.patch?full_index=1";
+      hash = "sha256-oBAUrcARYhJJfEgHbfP/KRpaGqamqBeEtHimcR/v0IA=";
+    };
+  }
+  {
+    name = "arm64: dts: mediatek: mt7988: add basic ethernet-nodes";
+    patch = fetchpatch2 {
+      url = "https://github.com/frank-w/BPI-Router-Linux/commit/57e1b74084ba42cec1177ec6baa87426c25a56ff.patch?full_index=1";
+      hash = "sha256-hHpN4WICph0gec452kvM98TTT2L+8g/K6N53ByWZluk=";
+    };
+  }
+  {
+    name = "arm64: dts: mediatek: mt7988: add switch node";
+    patch = fetchpatch2 {
+      url = "https://github.com/frank-w/BPI-Router-Linux/commit/1ae0def0b269c96c74abbca2d4d76ab89929237d.patch?full_index=1";
+      hash = "sha256-AnND42+aO9Lhn7T53ZqfazoxzbqNfyFosn1p3t918rw=";
+    };
+  }
+  {
+    name = "arm64: dts: mediatek: mt7988a-bpi-r4: add aliases for ethernet";
+    patch = fetchpatch2 {
+      url = "https://github.com/frank-w/BPI-Router-Linux/commit/94c6893d69eaac980117ef3eaf36d5bf83bb4625.patch?full_index=1";
+      hash = "sha256-p8oi+V2BRFh6Rk4kt01WIvmBL1kA7kK5NqXYpMbGYDY=";
+    };
+  }
+  {
+    name = "arm64: dts: mediatek: mt7988a-bpi-r4: add sfp cages and link to gmac";
+    patch = fetchpatch2 {
+      url = "https://github.com/frank-w/BPI-Router-Linux/commit/9751629b0ba547380e4db72675050c97dbecca25.patch?full_index=1";
+      hash = "sha256-lHrrP/DhXJbse6KUbsCCYiDE4b0zJqNVDuc0vZddYQ8=";
+    };
+  }
+  {
+    name = "arm64: dts: mediatek: mt7988a-bpi-r4: configure switch phys and leds";
+    patch = fetchpatch2 {
+      url = "https://github.com/frank-w/BPI-Router-Linux/commit/c4f62e2309f8d3df7a700114124c6f7b75760a58.patch?full_index=1";
+      hash = "sha256-ib3Z5VMtQJm5u1rWcr5bPALYfbviu1x0okuKqfq18b8=";
+    };
+  }
+  {
+    name = "dt-bindings: net: pcs: mediatek,sgmiisys: add phys and resets";
+    patch = fetchpatch2 {
+      url = "https://github.com/frank-w/BPI-Router-Linux/commit/7fe990d4181fa68be99aea5558c68a881b4b3289.patch?full_index=1";
+      hash = "sha256-Wi1wC1XEQfAQfAqr04BC5QQ6u0b4FO+rI2ah/ogfW/w=";
+    };
+  }
+]


### PR DESCRIPTION
~~6.17 is still an RC~~, and there's still much more cleanup to be done here.

~~On a clean system `fetchpatch` returns a different hash than `nix store prefetch-file`, the patch hashes only worked for me when prefetching with `nix store prefetch-file`.~~

Closes: #43