### PR TITLE
docs: fix example flake url

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Not all devices are supported on all boards.
   description = "NixOS configuration with flakes";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixos-sbc.url = "github:nakato/nixos-sbc/master";
+    nixos-sbc.url = "github:nakato/nixos-sbc";
   };
 
   outputs = { self, nixpkgs, nixos-sbc }: {


### PR DESCRIPTION
The flake URL provided in the example no longer aligns with the default branch of this repository (it is no `main` and no longer `master`).

This PR updates the flake input in the example to reflect that.